### PR TITLE
PyProject for Lint Consistency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 88
+target-version = ['py39', 'py310']
+include = '\.pyi?$'
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
Black & Isort have different line lengths by default (`78` vs `88`) which started causing conflicts in CI. The conclusion was to use Black's default configuration was chosen over Isort's

This is a preventive PR so that CI will continue to pass