### PR TITLE
[CTFTime] `upcoming` and `details` subcommands

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -18,6 +18,7 @@ jobs:
     concurrency:
       group: "stage"
       cancel-in-progress: true
+    if: github.repository_owner == 'VikeSec'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/cogs/ctftime.py
+++ b/cogs/ctftime.py
@@ -65,7 +65,7 @@ class CFTTime(commands.Cog):
 
         embed.add_field(name="Start", value=ISOToHammerTime(event["start"]))
         embed.add_field(name="Finish", value=ISOToHammerTime(event["finish"]))
-        embed.add_field(name="Weight", value=event["weight"])
+        embed.add_field(name="Weight", value=str(int(event["weight"])))
         embed.add_field(name="CTF Website", value=event["url"])
         embed.add_field(name="CTFtime", value=f'[{event["id"]}]({event["ctftime_url"]})')
         embed.add_field(name=f"Organizer", value=organizer)

--- a/cogs/ctftime.py
+++ b/cogs/ctftime.py
@@ -1,9 +1,11 @@
-import requests
+from datetime import datetime
+
 import discord
+import requests
 from discord.ext import commands
+
 from .utils.ctftimeapiutils import fetch_event_details, fetch_upcoming_events
 
-from datetime import datetime, tzinfo
 
 class CFTTime(commands.Cog):
 

--- a/cogs/ctftime.py
+++ b/cogs/ctftime.py
@@ -1,0 +1,10 @@
+import discord
+from discord.ext import commands
+
+class CFTTime(commands.Cog):
+
+    def __init__(self, bot):
+        self.bot = bot
+    
+def setup(bot):
+    bot.add_cog(CFTTime(bot))

--- a/cogs/ctftime.py
+++ b/cogs/ctftime.py
@@ -39,7 +39,9 @@ class CFTTime(commands.Cog):
             embeds.append(embed)
         await ctx.respond(embeds=embeds)
 
-    @ctftime.command(description="Show detailed information for an event with the given id")
+    @ctftime.command(
+        description="Show detailed information for an event with the given id"
+    )
     async def details(self, ctx, event_id: int):
         try:
             event = fetch_event_details(event_id)
@@ -53,7 +55,7 @@ class CFTTime(commands.Cog):
         # Format times
         utctime = int(datetime.fromisoformat(event["start"]).timestamp())
         formatted_start_time = f"<t:{utctime}:f>"
-        
+
         utctime = int(datetime.fromisoformat(event["finish"]).timestamp())
         formatted_finish_time = f"<t:{utctime}:f>"
         # Format duration
@@ -85,9 +87,9 @@ class CFTTime(commands.Cog):
         embed.add_field(name=f"Format", value=event["format"])
         embed.add_field(name=f"Participants", value=str(event["participants"]))
         embed.add_field(name=f"CTFtime URL", value=event["ctftime_url"])
-        if (event["location"]):
+        if event["location"]:
             embed.add_field(name=f"Location", value=event["location"])
-        if (event["live_feed"]):
+        if event["live_feed"]:
             embed.add_field(name=f"Live feed", value=event["live_feed"])
         embed.add_field(name=f"Public votable", value=str(event["public_votable"]))
         await ctx.respond(embed=embed)

--- a/cogs/ctftime.py
+++ b/cogs/ctftime.py
@@ -1,7 +1,7 @@
 import requests
 import discord
 from discord.ext import commands
-from .utils.ctftimeapiutils import fetch_event_info, fetch_upcoming_events
+from .utils.ctftimeapiutils import fetch_event_details, fetch_upcoming_events
 
 from datetime import datetime, tzinfo
 
@@ -29,6 +29,7 @@ class CFTTime(commands.Cog):
             events = fetch_upcoming_events(5)
         except requests.exceptions.HTTPError as ex:
             print(f"An error occurred when fetching event info: {ex}")
+            ctx.send("Sorry, I'm having trouble fetching the upcoming events.")
             return
 
         # Create an embed for each event
@@ -51,14 +52,52 @@ class CFTTime(commands.Cog):
 
     @ctftime.command()
     async def details(self, ctx, event_id: int):
-        await ctx.send(f'Details for CTF event with ID {event_id}: ...')
-
         try:
-            event = fetch_upcoming_events(5)
+            event = fetch_event_details(event_id)
         except requests.exceptions.HTTPError as ex:
             print(f"An error occurred when fetching event info: {ex}")
+            ctx.send("Sorry, I'm having trouble fetching the details for this event. Are you sure this is a valid event id?")
             return
+        
+        # Convert start time to localtime
+        utctime = datetime.fromisoformat(event["start"])
+        localtime = utctime.astimezone()
+        formatted_start_time = localtime.strftime(f'%B %d %-l:%M%p')
+        # Convert finish time to localtime
+        utctime = datetime.fromisoformat(event["finish"])
+        localtime = utctime.astimezone()
+        formatted_finish_time = localtime.strftime(f'%B %d %-l:%M%p')
+        # Format duration
+        formatted_duration = f'{event["duration"]["days"]} days {event["duration"]["hours"]} hours'
+        
+        embed = discord.Embed(
+            title=event["title"],
+            description=event["description"],
+            color=discord.Color.blue()
+        )
+        embed.set_thumbnail(url=event["logo"])
 
-    
+        if len(event["organizers"]) > 1:
+            for index, org in enumerate(event["organizers"]):
+                embed.add_field(name=f"Organizer {index}", value=org["name"])
+                embed.add_field(name=f"Organizer {index} Id", value=org["id"])
+        else:
+            embed.add_field(name=f"Organizer", value=event["organizers"][0]["name"])
+            embed.add_field(name=f"Organizer Id", value=event["organizers"][0]["id"])
+        
+        embed.add_field(name=f"Start", value=formatted_start_time)
+        embed.add_field(name=f"Finish", value=formatted_finish_time)
+        embed.add_field(name=f"Duration", value=formatted_duration)
+        embed.add_field(name=f"Website", value=event["url"])
+        embed.add_field(name=f"Is votable now", value=str(event["is_votable_now"]))
+        embed.add_field(name=f"Restrictions", value=event["restrictions"])
+        embed.add_field(name=f"Format", value=event["format"])
+        embed.add_field(name=f"Participants", value=str(event["participants"]))
+        embed.add_field(name=f"CTFtime URL", value=event["ctftime_url"])
+        embed.add_field(name=f"Location", value=event["location"])
+        embed.add_field(name=f"Live feed", value=event["live_feed"])
+        embed.add_field(name=f"Public votable", value=str(event["public_votable"]))
+        await ctx.send(embed=embed)
+
 def setup(bot):
     bot.add_cog(CFTTime(bot))

--- a/cogs/ctftime.py
+++ b/cogs/ctftime.py
@@ -27,18 +27,24 @@ class CFTTime(commands.Cog):
         # Create an embed for each event
         embeds = []
         for event in events:
-            embed = discord.Embed(title=event["title"], color=consistentHash(event["id"]))
+            embed = discord.Embed(
+                title=event["title"], color=consistentHash(event["id"])
+            )
             embed.set_thumbnail(url=event["logo"])
 
             embed.add_field(name="Start", value=ISOToHammerTime(event["start"]))
             embed.add_field(name="Finish", value=ISOToHammerTime(event["finish"]))
-            embed.add_field(name="", value="") # Empty field to make two columns
+            embed.add_field(name="", value="")  # Empty field to make two columns
             embed.add_field(name="Website", value=f'[CTFd]({event["url"]})')
-            embed.add_field(name="CTFtime", value=f'[{event["id"]}]({event["ctftime_url"]})')
-            embed.add_field(name="", value="") # Empty field to make the rows the same length
+            embed.add_field(
+                name="CTFtime", value=f'[{event["id"]}]({event["ctftime_url"]})'
+            )
+            embed.add_field(
+                name="", value=""
+            )  # Empty field to make the rows the same length
 
             embeds.append(embed)
-        
+
         await ctx.respond(embeds=embeds)
 
     @ctftime.command(
@@ -57,7 +63,7 @@ class CFTTime(commands.Cog):
         embed = discord.Embed(
             title=event["title"],
             description=event["description"],
-            color=consistentHash(event["id"])
+            color=consistentHash(event["id"]),
         )
         embed.set_thumbnail(url=event["logo"])
 
@@ -65,7 +71,9 @@ class CFTTime(commands.Cog):
         embed.add_field(name="Finish", value=ISOToHammerTime(event["finish"]))
         embed.add_field(name="Weight", value=str(int(event["weight"])))
         embed.add_field(name="Website", value=f'[CTFd]({event["url"]})')
-        embed.add_field(name="CTFtime", value=f'[{event["id"]}]({event["ctftime_url"]})')
+        embed.add_field(
+            name="CTFtime", value=f'[{event["id"]}]({event["ctftime_url"]})'
+        )
         organizer = f'[{event["organizers"][0]["name"]}](https://ctftime.org/team/{event["organizers"][0]["id"]})'
         embed.add_field(name=f"Organizer", value=organizer)
         embed.add_field(name=f"Restrictions", value=event["restrictions"])
@@ -73,14 +81,17 @@ class CFTTime(commands.Cog):
         embed.add_field(name=f"Participants", value=str(event["participants"]))
         await ctx.respond(embed=embed)
 
+
 def consistentHash(txt):
     return int(hex(hash(str(txt)))[3:9], 16)
+
 
 # Convert a string from ISO format to HammerTime format
 def ISOToHammerTime(time):
     utctime = int(datetime.fromisoformat(time).timestamp())
     formatted_time = f"<t:{utctime}:f>"
     return formatted_time
+
 
 def setup(bot):
     bot.add_cog(CFTTime(bot))

--- a/cogs/ctftime.py
+++ b/cogs/ctftime.py
@@ -8,20 +8,22 @@ from .utils.ctftimeapiutils import fetch_event_details, fetch_upcoming_events
 
 
 class CFTTime(commands.Cog):
-
     def __init__(self, bot):
         self.bot = bot
-    
+
     @commands.group()
     async def ctftime(self, ctx):
         # Default command that shows a list of subcommands
         if ctx.invoked_subcommand is None:
-            embed = discord.Embed(
-                title="CTFTime Commands",
-                color=discord.Color.blue()
+            embed = discord.Embed(title="CTFTime Commands", color=discord.Color.blue())
+            embed.add_field(
+                name="upcoming", value="Show upcoming CTF events.", inline=False
             )
-            embed.add_field(name="upcoming", value="Show upcoming CTF events.", inline=False)
-            embed.add_field(name="details [event_id]", value="Show details of a CTF event with the specified ID.", inline=False)
+            embed.add_field(
+                name="details [event_id]",
+                value="Show details of a CTF event with the specified ID.",
+                inline=False,
+            )
             await ctx.send(embed=embed)
 
     @ctftime.command()
@@ -36,21 +38,17 @@ class CFTTime(commands.Cog):
 
         # Create an embed for each event
         for event in events:
-            embed = discord.Embed(
-                title=event["title"],
-                color=discord.Color.blue()
-            )
+            embed = discord.Embed(title=event["title"], color=discord.Color.blue())
 
             # Convert start time to localtime
             utctime = datetime.fromisoformat(event["start"])
             localtime = utctime.astimezone()
-            formatted_time = localtime.strftime(f'%B %d %-l:%M%p')
+            formatted_time = localtime.strftime(f"%B %d %-l:%M%p")
 
             embed.add_field(name="Start time", value=formatted_time, inline=False)
             embed.add_field(name="Website", value=event["url"], inline=False)
             embed.add_field(name="Event id", value=event["id"], inline=False)
             await ctx.send(embed=embed)
-            
 
     @ctftime.command()
     async def details(self, ctx, event_id: int):
@@ -58,24 +56,28 @@ class CFTTime(commands.Cog):
             event = fetch_event_details(event_id)
         except requests.exceptions.HTTPError as ex:
             print(f"An error occurred when fetching event info: {ex}")
-            ctx.send("Sorry, I'm having trouble fetching the details for this event. Are you sure this is a valid event id?")
+            ctx.send(
+                "Sorry, I'm having trouble fetching the details for this event. Are you sure this is a valid event id?"
+            )
             return
-        
+
         # Convert start time to localtime
         utctime = datetime.fromisoformat(event["start"])
         localtime = utctime.astimezone()
-        formatted_start_time = localtime.strftime(f'%B %d %-l:%M%p')
+        formatted_start_time = localtime.strftime(f"%B %d %-l:%M%p")
         # Convert finish time to localtime
         utctime = datetime.fromisoformat(event["finish"])
         localtime = utctime.astimezone()
-        formatted_finish_time = localtime.strftime(f'%B %d %-l:%M%p')
+        formatted_finish_time = localtime.strftime(f"%B %d %-l:%M%p")
         # Format duration
-        formatted_duration = f'{event["duration"]["days"]} days {event["duration"]["hours"]} hours'
-        
+        formatted_duration = (
+            f'{event["duration"]["days"]} days {event["duration"]["hours"]} hours'
+        )
+
         embed = discord.Embed(
             title=event["title"],
             description=event["description"],
-            color=discord.Color.blue()
+            color=discord.Color.blue(),
         )
         embed.set_thumbnail(url=event["logo"])
 
@@ -86,7 +88,7 @@ class CFTTime(commands.Cog):
         else:
             embed.add_field(name=f"Organizer", value=event["organizers"][0]["name"])
             embed.add_field(name=f"Organizer Id", value=event["organizers"][0]["id"])
-        
+
         embed.add_field(name=f"Start", value=formatted_start_time)
         embed.add_field(name=f"Finish", value=formatted_finish_time)
         embed.add_field(name=f"Duration", value=formatted_duration)
@@ -100,6 +102,7 @@ class CFTTime(commands.Cog):
         embed.add_field(name=f"Live feed", value=event["live_feed"])
         embed.add_field(name=f"Public votable", value=str(event["public_votable"]))
         await ctx.send(embed=embed)
+
 
 def setup(bot):
     bot.add_cog(CFTTime(bot))

--- a/cogs/ctftime.py
+++ b/cogs/ctftime.py
@@ -21,22 +21,23 @@ class CFTTime(commands.Cog):
             events = fetch_upcoming_events(5)
         except requests.exceptions.HTTPError as ex:
             print(f"An error occurred when fetching event info: {ex}")
-            ctx.respond("Sorry, I'm having trouble fetching the upcoming events.")
+            await ctx.respond("Sorry, I'm having trouble fetching the upcoming events.")
             return
 
         # Create an embed for each event
         embeds = []
         for event in events:
-            embed = discord.Embed(title=event["title"], color=discord.Color.blue())
+            embed = discord.Embed(title=event["title"], color=consistentHash(event["id"]))
 
-            # Format start time
-            utctime = int(datetime.fromisoformat(event["start"]).timestamp())
-            formatted_start_time = f"<t:{utctime}:f>"
+            embed.add_field(name="Start", value=ISOToHammerTime(event["start"]))
+            embed.add_field(name="Finish", value=ISOToHammerTime(event["finish"]))
+            embed.add_field(name="", value="") # Empty field to make two columns
+            embed.add_field(name="CTF Website", value=event["url"])
+            embed.add_field(name="CTFtime", value=f'[{event["id"]}]({event["ctftime_url"]})')
+            embed.add_field(name="", value="") # Empty field to make the rows the same length
 
-            embed.add_field(name="Start time", value=formatted_start_time, inline=False)
-            embed.add_field(name="Website", value=event["url"], inline=False)
-            embed.add_field(name="Event id", value=event["id"], inline=False)
             embeds.append(embed)
+        
         await ctx.respond(embeds=embeds)
 
     @ctftime.command(
@@ -47,55 +48,40 @@ class CFTTime(commands.Cog):
             event = fetch_event_details(event_id)
         except requests.exceptions.HTTPError as ex:
             print(f"An error occurred when fetching event info: {ex}")
-            ctx.respond(
+            await ctx.respond(
                 "Sorry, I'm having trouble fetching the details for this event. Are you sure this is a valid event id?"
             )
             return
 
-        # Format times
-        utctime = int(datetime.fromisoformat(event["start"]).timestamp())
-        formatted_start_time = f"<t:{utctime}:f>"
-
-        utctime = int(datetime.fromisoformat(event["finish"]).timestamp())
-        formatted_finish_time = f"<t:{utctime}:f>"
-        # Format duration
-        formatted_duration = ""
-        if event["duration"]["days"] > 0:
-            formatted_duration += f'{event["duration"]["days"]} days '
-        if event["duration"]["hours"] > 0:
-            formatted_duration += f'{event["duration"]["hours"]} hours'
-
         embed = discord.Embed(
             title=event["title"],
             description=event["description"],
-            color=discord.Color.blue(),
+            color=consistentHash(event["id"])
         )
         embed.set_thumbnail(url=event["logo"])
 
-        if len(event["organizers"]) > 1:
-            for index, org in enumerate(event["organizers"]):
-                embed.add_field(name=f"Organizer {index}", value=org["name"])
-                embed.add_field(name=f"Organizer {index} Id", value=org["id"])
-        else:
-            embed.add_field(name=f"Organizer", value=event["organizers"][0]["name"])
-            embed.add_field(name=f"Organizer Id", value=event["organizers"][0]["id"])
+        # Format organizer
+        organizer = f'[{event["organizers"][0]["name"]}](https://ctftime.org/team/{event["organizers"][0]["id"]})'
 
-        embed.add_field(name=f"Start", value=formatted_start_time)
-        embed.add_field(name=f"Finish", value=formatted_finish_time)
-        embed.add_field(name=f"Duration", value=formatted_duration)
-        embed.add_field(name=f"Website", value=event["url"])
-        embed.add_field(name=f"Is votable now", value=str(event["is_votable_now"]))
+        embed.add_field(name="Start", value=ISOToHammerTime(event["start"]))
+        embed.add_field(name="Finish", value=ISOToHammerTime(event["finish"]))
+        embed.add_field(name="Weight", value=event["weight"])
+        embed.add_field(name="CTF Website", value=event["url"])
+        embed.add_field(name="CTFtime", value=f'[{event["id"]}]({event["ctftime_url"]})')
+        embed.add_field(name=f"Organizer", value=organizer)
         embed.add_field(name=f"Restrictions", value=event["restrictions"])
         embed.add_field(name=f"Format", value=event["format"])
         embed.add_field(name=f"Participants", value=str(event["participants"]))
-        embed.add_field(name=f"CTFtime URL", value=event["ctftime_url"])
-        if event["location"]:
-            embed.add_field(name=f"Location", value=event["location"])
-        if event["live_feed"]:
-            embed.add_field(name=f"Live feed", value=event["live_feed"])
-        embed.add_field(name=f"Public votable", value=str(event["public_votable"]))
         await ctx.respond(embed=embed)
 
+def consistentHash(txt):
+    return int(hex(hash(str(txt)))[3:9], 16)
+
+# Convert a string from ISO format to HammerTime format
+def ISOToHammerTime(time):
+    utctime = int(datetime.fromisoformat(time).timestamp())
+    formatted_time = f"<t:{utctime}:f>"
+    return formatted_time
 
 def setup(bot):
     bot.add_cog(CFTTime(bot))

--- a/cogs/ctftime.py
+++ b/cogs/ctftime.py
@@ -59,9 +59,11 @@ class CFTTime(commands.Cog):
         utctime = int(datetime.fromisoformat(event["finish"]).timestamp())
         formatted_finish_time = f"<t:{utctime}:f>"
         # Format duration
-        formatted_duration = (
-            f'{event["duration"]["days"]} days {event["duration"]["hours"]} hours'
-        )
+        formatted_duration = ""
+        if event["duration"]["days"] > 0:
+            formatted_duration += f'{event["duration"]["days"]} days '
+        if event["duration"]["hours"] > 0:
+            formatted_duration += f'{event["duration"]["hours"]} hours'
 
         embed = discord.Embed(
             title=event["title"],

--- a/cogs/ctftime.py
+++ b/cogs/ctftime.py
@@ -33,7 +33,7 @@ class CFTTime(commands.Cog):
             embed.add_field(name="Start", value=ISOToHammerTime(event["start"]))
             embed.add_field(name="Finish", value=ISOToHammerTime(event["finish"]))
             embed.add_field(name="", value="") # Empty field to make two columns
-            embed.add_field(name="CTF Website", value=event["url"])
+            embed.add_field(name="Website", value=f'[CTFd]({event["url"]})')
             embed.add_field(name="CTFtime", value=f'[{event["id"]}]({event["ctftime_url"]})')
             embed.add_field(name="", value="") # Empty field to make the rows the same length
 
@@ -61,14 +61,12 @@ class CFTTime(commands.Cog):
         )
         embed.set_thumbnail(url=event["logo"])
 
-        # Format organizer
-        organizer = f'[{event["organizers"][0]["name"]}](https://ctftime.org/team/{event["organizers"][0]["id"]})'
-
         embed.add_field(name="Start", value=ISOToHammerTime(event["start"]))
         embed.add_field(name="Finish", value=ISOToHammerTime(event["finish"]))
         embed.add_field(name="Weight", value=str(int(event["weight"])))
-        embed.add_field(name="CTF Website", value=event["url"])
+        embed.add_field(name="Website", value=f'[CTFd]({event["url"]})')
         embed.add_field(name="CTFtime", value=f'[{event["id"]}]({event["ctftime_url"]})')
+        organizer = f'[{event["organizers"][0]["name"]}](https://ctftime.org/team/{event["organizers"][0]["id"]})'
         embed.add_field(name=f"Organizer", value=organizer)
         embed.add_field(name=f"Restrictions", value=event["restrictions"])
         embed.add_field(name=f"Format", value=event["format"])

--- a/cogs/ctftime.py
+++ b/cogs/ctftime.py
@@ -28,6 +28,7 @@ class CFTTime(commands.Cog):
         embeds = []
         for event in events:
             embed = discord.Embed(title=event["title"], color=consistentHash(event["id"]))
+            embed.set_thumbnail(url=event["logo"])
 
             embed.add_field(name="Start", value=ISOToHammerTime(event["start"]))
             embed.add_field(name="Finish", value=ISOToHammerTime(event["finish"]))

--- a/cogs/ctftime.py
+++ b/cogs/ctftime.py
@@ -1,5 +1,9 @@
+import requests
 import discord
 from discord.ext import commands
+from .utils.ctftimeapiutils import fetch_event_info, fetch_upcoming_events
+
+from datetime import datetime, tzinfo
 
 class CFTTime(commands.Cog):
 
@@ -8,10 +12,10 @@ class CFTTime(commands.Cog):
     
     @commands.group()
     async def ctftime(self, ctx):
+        # Default command that shows a list of subcommands
         if ctx.invoked_subcommand is None:
             embed = discord.Embed(
                 title="CTFTime Commands",
-                description="Please use one of the following subcommands:",
                 color=discord.Color.blue()
             )
             embed.add_field(name="upcoming", value="Show upcoming CTF events.", inline=False)
@@ -20,11 +24,40 @@ class CFTTime(commands.Cog):
 
     @ctftime.command()
     async def upcoming(self, ctx):
-        await ctx.send('Upcoming CTF events: ...')
+        # Get 5 upcoming events
+        try:
+            events = fetch_upcoming_events(5)
+        except requests.exceptions.HTTPError as ex:
+            print(f"An error occurred when fetching event info: {ex}")
+            return
+
+        # Create an embed for each event
+        for event in events:
+            embed = discord.Embed(
+                title=event["title"],
+                color=discord.Color.blue()
+            )
+
+            # Convert start time to localtime
+            utctime = datetime.fromisoformat(event["start"])
+            localtime = utctime.astimezone()
+            formatted_time = localtime.strftime(f'%B %d %-l:%M%p')
+
+            embed.add_field(name="Start time", value=formatted_time, inline=False)
+            embed.add_field(name="Website", value=event["url"], inline=False)
+            embed.add_field(name="Event id", value=event["id"], inline=False)
+            await ctx.send(embed=embed)
+            
 
     @ctftime.command()
     async def details(self, ctx, event_id: int):
         await ctx.send(f'Details for CTF event with ID {event_id}: ...')
+
+        try:
+            event = fetch_upcoming_events(5)
+        except requests.exceptions.HTTPError as ex:
+            print(f"An error occurred when fetching event info: {ex}")
+            return
 
     
 def setup(bot):

--- a/cogs/ctftime.py
+++ b/cogs/ctftime.py
@@ -6,5 +6,26 @@ class CFTTime(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
     
+    @commands.group()
+    async def ctftime(self, ctx):
+        if ctx.invoked_subcommand is None:
+            embed = discord.Embed(
+                title="CTFTime Commands",
+                description="Please use one of the following subcommands:",
+                color=discord.Color.blue()
+            )
+            embed.add_field(name="upcoming", value="Show upcoming CTF events.", inline=False)
+            embed.add_field(name="details [event_id]", value="Show details of a CTF event with the specified ID.", inline=False)
+            await ctx.send(embed=embed)
+
+    @ctftime.command()
+    async def upcoming(self, ctx):
+        await ctx.send('Upcoming CTF events: ...')
+
+    @ctftime.command()
+    async def details(self, ctx, event_id: int):
+        await ctx.send(f'Details for CTF event with ID {event_id}: ...')
+
+    
 def setup(bot):
     bot.add_cog(CFTTime(bot))

--- a/cogs/utils/ctftimeapiutils.py
+++ b/cogs/utils/ctftimeapiutils.py
@@ -4,7 +4,7 @@ import config
 
 baseurl = 'https://ctftime.org/api/v1/'
 
-def fetch_event_info(event_id):
+def fetch_event_details(event_id):
     url = baseurl + 'events/' + str(event_id) + '/'
     headers = {'user-agent': config.user_agent}
 

--- a/cogs/utils/ctftimeapiutils.py
+++ b/cogs/utils/ctftimeapiutils.py
@@ -3,6 +3,7 @@ import requests
 baseurl = "https://ctftime.org/api/v1/"
 USER_AGENT_HEADER = "VikeBot"
 
+
 def fetch_event_details(event_id):
     url = baseurl + "events/" + str(event_id) + "/"
     headers = {"user-agent": USER_AGENT_HEADER}

--- a/cogs/utils/ctftimeapiutils.py
+++ b/cogs/utils/ctftimeapiutils.py
@@ -2,23 +2,25 @@ import requests
 
 import config
 
-baseurl = 'https://ctftime.org/api/v1/'
+baseurl = "https://ctftime.org/api/v1/"
+
 
 def fetch_event_details(event_id):
-    url = baseurl + 'events/' + str(event_id) + '/'
-    headers = {'user-agent': config.user_agent}
+    url = baseurl + "events/" + str(event_id) + "/"
+    headers = {"user-agent": config.user_agent}
 
     response = requests.get(url, headers=headers)
-    response.raise_for_status() # Throws exception when code >= 400
-    
+    response.raise_for_status()  # Throws exception when code >= 400
+
     return response.json()
 
+
 def fetch_upcoming_events(num_events):
-    url = baseurl + 'events/'
-    params = {'limit': str(num_events)}
-    headers = {'user-agent': config.user_agent}
-    
+    url = baseurl + "events/"
+    params = {"limit": str(num_events)}
+    headers = {"user-agent": config.user_agent}
+
     response = requests.get(url, params=params, headers=headers)
-    response.raise_for_status() # Throws exception when code >= 400
-    
+    response.raise_for_status()  # Throws exception when code >= 400
+
     return response.json()

--- a/cogs/utils/ctftimeapiutils.py
+++ b/cogs/utils/ctftimeapiutils.py
@@ -1,0 +1,18 @@
+import requests
+
+baseurl = 'https://ctftime.org/api/v1/'
+
+def get_event_info(event_id):
+    url = baseurl + 'events/' + event_id + '/'
+    
+    response = requests.get(url)
+    return response.json()
+
+def get_upcoming_events(num_events):
+    url = baseurl + 'events/'
+    params = {'limit': num_events}
+
+    response = requests.get(url, params)
+    return response.json()
+
+

--- a/cogs/utils/ctftimeapiutils.py
+++ b/cogs/utils/ctftimeapiutils.py
@@ -1,13 +1,11 @@
 import requests
 
-import config
-
 baseurl = "https://ctftime.org/api/v1/"
-
+USER_AGENT_HEADER = "VikeBot"
 
 def fetch_event_details(event_id):
     url = baseurl + "events/" + str(event_id) + "/"
-    headers = {"user-agent": config.user_agent}
+    headers = {"user-agent": USER_AGENT_HEADER}
 
     response = requests.get(url, headers=headers)
     response.raise_for_status()  # Throws exception when code >= 400
@@ -18,7 +16,7 @@ def fetch_event_details(event_id):
 def fetch_upcoming_events(num_events):
     url = baseurl + "events/"
     params = {"limit": str(num_events)}
-    headers = {"user-agent": config.user_agent}
+    headers = {"user-agent": USER_AGENT_HEADER}
 
     response = requests.get(url, params=params, headers=headers)
     response.raise_for_status()  # Throws exception when code >= 400

--- a/cogs/utils/ctftimeapiutils.py
+++ b/cogs/utils/ctftimeapiutils.py
@@ -1,18 +1,24 @@
 import requests
 
+import config
+
 baseurl = 'https://ctftime.org/api/v1/'
 
-def get_event_info(event_id):
-    url = baseurl + 'events/' + event_id + '/'
+def fetch_event_info(event_id):
+    url = baseurl + 'events/' + str(event_id) + '/'
+    headers = {'user-agent': config.user_agent}
+
+    response = requests.get(url, headers=headers)
+    response.raise_for_status() # Throws exception when code >= 400
     
-    response = requests.get(url)
     return response.json()
 
-def get_upcoming_events(num_events):
+def fetch_upcoming_events(num_events):
     url = baseurl + 'events/'
-    params = {'limit': num_events}
-
-    response = requests.get(url, params)
+    params = {'limit': str(num_events)}
+    headers = {'user-agent': config.user_agent}
+    
+    response = requests.get(url, params=params, headers=headers)
+    response.raise_for_status() # Throws exception when code >= 400
+    
     return response.json()
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp==3.8.1
 py-cord==2.0.0b1
 psutil==5.8.0
+requests==2.28.1


### PR DESCRIPTION
Added ctftime cog with base command and `upcoming` and `details` subcommands.

Closes: #12

Suggestion: Should I add an optional num_events argument to upcoming command that defaults to 5 events? 

Changes ignored by git:
- config.py attribute user_agent was added and is sent to ctftime API as the user-agent header, this header is required by the API.
- docker container environment variable TZ="Canada/Pacific" must be set, otherwise the times shown will be in the default timezone of the image (UTC).